### PR TITLE
bugfix: elysia ElysiaCustomStatusResponse constructor name matching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ function handleResponseBody(
 function isElysiaCustomStatusResponse(
   obj: unknown,
 ): obj is ElysiaCustomStatusResponse<any, any> {
-  return obj?.constructor?.name === ElysiaCustomStatusResponse.name;
+  return obj?.constructor?.name === "ElysiaCustomStatusResponse";
 }
 
 function isResponse(obj: unknown): obj is Response {
@@ -125,14 +125,14 @@ export const protobuf = <T extends Schemas>(
     )
     .macro({
       responseSchema: (name: keyof T) => ({
-        afterHandle: async ({ response, set }) => {
+        afterHandle: async ({ response, set, status }) => {
           if (!response || typeof response !== "object") {
             throw new ProtoResponseError("Response must be an object");
           }
           set.headers["content-type"] = "application/x-protobuf";
 
           if (isElysiaCustomStatusResponse(response)) {
-            return new ElysiaCustomStatusResponse(
+            return status(
               response.code,
               handleResponseBody(response.response, schemas[name]),
             );


### PR DESCRIPTION
I found a bug in the code when building a production minified build.  
During minification, the `ElysiaCustomStatusResponse` class is sometimes transformed into an anonymous class. As a result, there's no guarantee that `ElysiaCustomStatusResponse.name` will return the correct class name, and `instanceof` checks also fail.

I looked into the Elysia source code and noticed that this issue is handled using string comparison, as seen here:  
https://github.com/elysiajs/elysia/blob/0792b0660606c1055302d0bafd8ab669fcfde5f0/src/adapter/bun/handler.ts#L50

So, I modified the `isElysiaCustomStatusResponse` function to compare against a hardcoded string instead, and it worked!

Additionally, I updated the instantiation of `ElysiaCustomStatusResponse` to use the original Elysia status implementation, ensuring compatibility with their codebase.
